### PR TITLE
Fix IE11 error

### DIFF
--- a/line-polygon.js
+++ b/line-polygon.js
@@ -10,7 +10,7 @@ var lineLine = require('./line-line')
  @param {number[]} points of polygon
  @param {tolerance=1} maximum distance of point to polygon's edges that triggers collision (see pointLine)
  */
-module.exports = function linePolygon(x1, y1, x2, y2, points, tolerance = 1)
+module.exports = function linePolygon(x1, y1, x2, y2, points, tolerance)
 {
     var length = points.length
 

--- a/polygon-line.js
+++ b/polygon-line.js
@@ -10,7 +10,7 @@ var linePolygon = require('./line-polygon')
  * @param {tolerance=1} maximum distance of point to polygon's edges that triggers collision (see pointLine)
  * @return {boolean}
  */
-module.exports = function polygonLine(points, x1, y1, x2, y2, tolerance = 1)
+module.exports = function polygonLine(points, x1, y1, x2, y2, tolerance)
 {
     return linePolygon(x1, y1, x2, y2, points, tolerance)
 }

--- a/umd/intersects.js
+++ b/umd/intersects.js
@@ -716,7 +716,7 @@ var lineLine = require('./line-line')
  @param {number[]} points of polygon
  @param {tolerance=1} maximum distance of point to polygon's edges that triggers collision (see pointLine)
  */
-module.exports = function linePolygon(x1, y1, x2, y2, points, tolerance = 1)
+module.exports = function linePolygon(x1, y1, x2, y2, points, tolerance)
 {
     var length = points.length
 
@@ -912,7 +912,7 @@ var linePolygon = require('./line-polygon')
  * @param {tolerance=1} maximum distance of point to polygon's edges that triggers collision (see pointLine)
  * @return {boolean}
  */
-module.exports = function polygonLine(points, x1, y1, x2, y2, tolerance = 1)
+module.exports = function polygonLine(points, x1, y1, x2, y2, tolerance)
 {
     return linePolygon(x1, y1, x2, y2, points, tolerance)
 }


### PR DESCRIPTION
IE11 throws an error because of the default value for
tolerance argument. Since the default is being set on
`linePoint`, there is not need to define it on these methods.

@davidfig  I couldn't generate the minified version on my local machine, so I would appreciate if you could do it and release the new version if you are okay with these changes. thanks